### PR TITLE
Remove cam-slide from asset graph

### DIFF
--- a/ezmanager/controller/view_popup.php
+++ b/ezmanager/controller/view_popup.php
@@ -411,22 +411,18 @@ function asset_stats()
     
     $stats = array();
     if (count($all_view_time) > 0) {
-        $data_view_time = array('cam' => array(), 'slide' => array());
+        $data_view_time = array();
         $last_time = 0;
         foreach ($all_view_time as $view_time) {
-            if (!array_key_exists($view_time['type'], $data_view_time)) {
-                $data_view_time[$view_time['type']] = array();
-            }
             while ($view_time['video_time'] > $last_time) {
-                $data_view_time[$view_time['type']][] = 0;
+                $data_view_time[] = 0;
                 ++$last_time;
             }
-            $data_view_time[$view_time['type']][] = intval($view_time['nbr_view']);
+            $data_view_time[] = intval($view_time['nbr_view']);
             ++$last_time;
         }
         $stats['display'] = true;
-        $stats['str_view_time_cam'] = json_encode($data_view_time['cam']);
-        $stats['str_view_time_slide'] = json_encode($data_view_time['slide']);
+        $stats['str_view_time'] = json_encode($data_view_time);
     } else {
         $stats['display'] = false;
     }

--- a/ezmanager/lib_sql_stats.php
+++ b/ezmanager/lib_sql_stats.php
@@ -41,13 +41,14 @@ function stats_statements_get()
                 'GROUP BY asset, asset_name;',
         
             'video_get_view_time' =>
-                'SELECT video_time, nbr_view, type ' .
+                'SELECT SUM(video_time) AS video_time, nbr_view ' .
                 'FROM ' . db_gettable($table_stats_view) . ' ' .
                 'WHERE album = :album ' .
                     'AND ' .
                     'asset = :asset ' .
                     'AND ' .
                     'visibility = 1 ' .
+                'GROUP BY type ' .
                 'ORDER BY video_time;',
         
             'album_get_info' =>

--- a/ezmanager/tmpl_sources/popup_asset_stats.php
+++ b/ezmanager/tmpl_sources/popup_asset_stats.php
@@ -102,49 +102,14 @@
             shared: true,
             valueSuffix: ' ®Graph_views®',
             formatter: function() {
-                    var total = 0;
-                    var result = '';
-                    if(this.points[0] !== undefined) {
-                        result += '<b>' + this.points[0].series.name + ':</b> ' +
-                            this.points[0].y + ' ®Graph_views®<br />';
-                        total += this.points[0].y;
-                    }
-                    <?php if ($has_slides && $has_cam) { ?>
-                        if(this.points[1] !== undefined) {
-                            result += '<b>' + this.points[1].series.name + ':</b> ' +
-                                    this.points[1].y + ' ®Graph_views®<br />';
-                            total += this.points[1].y;
-                        }
-                    <?php } ?>
-                    
-                    <?php if ($has_cam && $has_slides) { ?>
-                        result += '<b>Total:</b> ' + total + ' ®Graph_views®';
-                    <?php } ?>
-                    return result;
+                    return this.points[0].y + ' ®Graph_views®';
                 }
         },
         series: [
-            <?php if ($has_slides) {
-            ?>
                 {
                     name: '®Graph_slide_view®',
-                    data: <?php echo $stats['str_view_time_slide']; ?>
+                    data: <?php echo $stats['str_view_time']; ?>
                 }
-            <?php
-        }
-        
-        if ($has_slides && $has_cam) {
-            echo ',';
-        }
-        
-        if ($has_cam) {
-            ?>
-                {
-                    name: '®Graph_cam_view®',
-                    data: <?php echo $stats['str_view_time_cam']; ?>
-                }
-            <?php
-        } ?>
         ]
     });
 <?php


### PR DESCRIPTION
Remove cam and slide in "asset graph" and keep only the sum.    
Currently the modification is only for the view...  Idealy, the database must also be update.