### PR TITLE
Ezmanager: Upload video: check real type file based on the mime type

### DIFF
--- a/ezmanager/config-sample.inc
+++ b/ezmanager/config-sample.inc
@@ -63,7 +63,7 @@ $title_max_length = 70; // Maximum number of characters for the title
 
 // used by ezmanager for asset submit
 $valid_extensions = array('mov', 'm4v', 'mp4', 'mpg4', 'mpg', 'nuv', 'ac3', 'mpeg4', 'avi', 'mpeg', 'flv', 'wmv', 'mka', 'mks', 'rmvb', 'divx', 'xvid', 'vob', 'mkv', 'f4v');
-
+$valid_mimeType = array('video/quicktime','video/ogg','video/h264','video/x-f4v','video/x-m4v','video/x-flv','video/mp4','application/x-mpegURL','video/MP2T','video/3gpp','video/3gpp2','video/quicktime','	video/x-msvideo','video/x-ms-wmv','video/x-msvideo','video/mpeg','video/ogg','video/webm');
 // used by web_index.php to set the size of each chunck of file that is uploaded via the submit form
 $upload_slice_size = 1024 * 1024;
 

--- a/ezmanager/controller/upload_chunk.php
+++ b/ezmanager/controller/upload_chunk.php
@@ -7,6 +7,7 @@
 function index($param = array())
 {
     global $accepted_media_types;
+    global $valid_mimeType;                       
     global $upload_slice_size;
 
     $array = array();
@@ -113,6 +114,13 @@ function index($param = array())
         $target = "$path/" . $type . '/' . $type . '-' . $index;
         $input = fopen("php://input", "r");
         file_put_contents($target, $input);
+    }
+    
+    if(!in_array(mime_content_type($target),$valid_mimeType)){
+        log_append('error', "Mimetype is not valid");
+        $array["error"] = template_get_message('mimetype_error', get_lang()).' type:'.mime_content_type($target);
+        echo json_encode($array);
+        die;    
     }
 
     if ($res === false) {

--- a/ezmanager/translations.xml
+++ b/ezmanager/translations.xml
@@ -605,6 +605,8 @@
         <message id="missing_chunks" lang="en">Access denied: missing file chunks</message>
         <message id="write_error" lang="fr">Une erreur est survenue à l'écriture du fichier sur le serveur</message>
         <message id="write_error" lang="en">An error occured while writting the file on the server</message>
+        <message id="mimetype_error" lang="fr">Une erreur est survenue, le type de fichier soumit n'est pas valide</message>
+        <message id="mimetype_error" lang="en">An error occured because of an incorect filetype</message>                                                                                     
     </messages>
     
         <!-- update 2016/07/15 -->


### PR DESCRIPTION
On upload in ezmanager:
Check the real file type based on the mime type and not only with the text extension.
Add a variable in config.inc to choose which mime types are accepted